### PR TITLE
CASMHMS-5431 Build hms-rts with GitHub Actions

### DIFF
--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2022-05-04
+
+### Changed
+
+- CASMHMS-5431: Bump hms-rts version to 1.16.0 for GitHub Actions transition.
+
 ## [2.0.0] - 2021-11-19
 
 ### Changed

--- a/charts/v2.0/cray-hms-rts/Chart.yaml
+++ b/charts/v2.0/cray-hms-rts/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-rts"
-version: 2.0.0
+version: 2.0.1
 description: "Kubernetes resources for cray-hms-rts"
 home: "https://github.com/Cray-HPE/hms-rts-charts"
 sources:
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.15.0"
+appVersion: "1.16.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.0/cray-hms-rts/values.yaml
+++ b/charts/v2.0/cray-hms-rts/values.yaml
@@ -1,6 +1,6 @@
 ---
 global:
-  appVersion: 1.15.0
+  appVersion: 1.16.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-redfish-translation-service

--- a/cray-hms-rts.compatibility.yaml
+++ b/cray-hms-rts.compatibility.yaml
@@ -10,6 +10,7 @@ chartVersionToCSMVersion:
 chartVersionToApplicationVersion:
   # Chart version: Application version
   "2.0.0": "1.15.0"
+  "2.0.1": "1.16.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

This PR includes the following changes:

- Update hms-rts to build using GitHub Actions instead of Jenkins
- Pull images from algol60 Artifactory instead of arti.dev.cray.com
- Update Alpine base image version
- Stop building CT test RPMs for hms-rts since the only tests were for checking the health of RTS pods and jobs in k8s which will be covered by the PET team moving forward. This is part of our transition to Helm-based CT tests instead of RPMs.

### Issues and Related PRs

* Resolves CASMHMS-5431.
* Resolves CASMHMS-5419.

### Testing

This change was tested by verifying that the new hms-rts version was built successfully using GitHub Actions and the resulting image was pushed to algol60 Artifactory. The newly built hms-rts was also spun up locally in a docker-compose environment. The unit tests for hms-rts were verified to pass in a GitHub Action workflow.

Was a fresh Install tested? N
Was an Upgrade tested? N
Was a Downgrade tested? N

### Risks and Mitigations

Low risk, only changing how hms-rts is built and where images that it depends on are pulled from.