### PR TITLE
CASMHMS-5578/5579: Pick up new application image & correct hostname for

### DIFF
--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,6 +5,13 @@ All notable changes to this project for v2.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2022-06-02
+
+### Changed
+
+- CASMHMS-5578: Bump application image version to 1.17.0 to pick up fix to only create redfish endpoints in HSM if they do not exist.
+- CASMHMS-5579: Updated the service name for the collector, as it was changed in CSM 1.2 to `cray-hms-hmcollector-ingress`.
+
 ## [2.0.1] - 2022-05-04
 
 ### Changed

--- a/charts/v2.0/cray-hms-rts/Chart.yaml
+++ b/charts/v2.0/cray-hms-rts/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-rts"
-version: 2.0.1
+version: 2.0.2
 description: "Kubernetes resources for cray-hms-rts"
 home: "https://github.com/Cray-HPE/hms-rts-charts"
 sources:
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.16.0"
+appVersion: "1.17.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.0/cray-hms-rts/values.yaml
+++ b/charts/v2.0/cray-hms-rts/values.yaml
@@ -1,6 +1,6 @@
 ---
 global:
-  appVersion: 1.16.0
+  appVersion: 1.17.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-redfish-translation-service
@@ -214,7 +214,7 @@ environment:
     hsm_url: "http://cray-smd"
     https_cert: "configs/rts.crt"
     https_key: "configs/rts.key"
-    collector_url: "http://cray-hms-hmcollector"
+    collector_url: "http://cray-hms-hmcollector-ingress"
     backend_helper: "JAWS"
     rts_dns_provider: "k8s_service"
     certificate_vault_keypath: "secret/pdu-creds/certificates"

--- a/cray-hms-rts.compatibility.yaml
+++ b/cray-hms-rts.compatibility.yaml
@@ -11,6 +11,7 @@ chartVersionToApplicationVersion:
   # Chart version: Application version
   "2.0.0": "1.15.0"
   "2.0.1": "1.16.0"
+  "2.0.2": "1.17.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
the collector

## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
- CASMHMS-5578: Bump application image version to 1.17.0 to pick up fix to only create redfish endpoints in HSM if they do not exist.
- CASMHMS-5579: Updated the service name for the collector, as it was changed in CSM 1.2 to `cray-hms-hmcollector-ingress`.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_ 

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMHMS-5578
* Resolves CASMHMS-5579

## Testing

_List the environments in which these changes were tested._

Tested on:
  * `<development system>`
  * Local development environment
  * Virtual Shasta

Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?


## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable