### PR TITLE
Change HSM v1 API references to v2

### DIFF
--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3] - 2022-06-30
+
+### Changed
+
+- Change HSM v1 API references to v2
+
 ## [2.0.2] - 2022-06-02
 
 ### Changed

--- a/charts/v2.0/cray-hms-rts/Chart.yaml
+++ b/charts/v2.0/cray-hms-rts/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-rts"
-version: 2.0.2
+version: 2.0.3
 description: "Kubernetes resources for cray-hms-rts"
 home: "https://github.com/Cray-HPE/hms-rts-charts"
 sources:
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.17.0"
+appVersion: "1.19.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.0/cray-hms-rts/values.yaml
+++ b/charts/v2.0/cray-hms-rts/values.yaml
@@ -1,6 +1,6 @@
 ---
 global:
-  appVersion: 1.17.0
+  appVersion: 1.19.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-redfish-translation-service

--- a/cray-hms-rts.compatibility.yaml
+++ b/cray-hms-rts.compatibility.yaml
@@ -12,6 +12,7 @@ chartVersionToApplicationVersion:
   "2.0.0": "1.15.0"
   "2.0.1": "1.16.0"
   "2.0.2": "1.17.0"
+  "2.0.3": "1.19.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Change HSM v1 API references to v2

## Issues and Related PRs

* Resolves [CASMHMS-5549](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5549)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable