### PR TITLE
CASMHMS-5607: Remove hardcoded certificate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,11 @@
 
 *.tgz
 Chart.lock
+
+# Prevent certificates from getting checked in
+*.ca
+*.cer
+*.crt
+*.csr
+*.key
+*.pem

--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.4] - 2022-07-20
+
+### Security
+- Removed hardcoded certificate from RTS container image.
+- Use cert-manager to generate the default HTTPs certificate for RTS.
+
 ## [2.0.3] - 2022-06-30
 
 ### Changed

--- a/charts/v2.0/cray-hms-rts/Chart.yaml
+++ b/charts/v2.0/cray-hms-rts/Chart.yaml
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.19.0-20220715214547.db9aedc"
+appVersion: 1.20.0
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.0/cray-hms-rts/Chart.yaml
+++ b/charts/v2.0/cray-hms-rts/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-rts"
-version: 2.0.3
+version: 2.0.4
 description: "Kubernetes resources for cray-hms-rts"
 home: "https://github.com/Cray-HPE/hms-rts-charts"
 sources:
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.19.0"
+appVersion: "1.19.0-20220715214547.db9aedc"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.0/cray-hms-rts/templates/certificate.yaml
+++ b/charts/v2.0/cray-hms-rts/templates/certificate.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: cert-manager.io/v1alpha3
+kind: Certificate
+metadata:
+  name: cray-hms-rts-default-tls
+spec:
+  commonName: cray-hms-rts.services.cluster.svc
+  dnsNames:
+  - cray-hms-rts.services.cluster.svc
+  - cray-hms-rts.services
+  - cray-hms-rts
+  duration: 720h0m0s
+  issuerRef:
+    kind: Issuer
+    name: cert-manager-issuer-common
+  keyAlgorithm: rsa
+  keyEncoding: pkcs1
+  keySize: 2048
+  renewBefore: 24h0m0s
+  secretName: cray-hms-rts-default-tls

--- a/charts/v2.0/cray-hms-rts/templates/certificate.yaml
+++ b/charts/v2.0/cray-hms-rts/templates/certificate.yaml
@@ -4,11 +4,11 @@ kind: Certificate
 metadata:
   name: cray-hms-rts-default-tls
 spec:
-  commonName: cray-hms-rts.services.cluster.svc
+  commonName: cray-hms-rts
   dnsNames:
+  - cray-hms-rts.services.cluster.svc.local
   - cray-hms-rts.services.cluster.svc
   - cray-hms-rts.services
-  - cray-hms-rts
   duration: 720h0m0s
   issuerRef:
     kind: Issuer

--- a/charts/v2.0/cray-hms-rts/values.yaml
+++ b/charts/v2.0/cray-hms-rts/values.yaml
@@ -1,6 +1,6 @@
 ---
 global:
-  appVersion: 1.19.0
+  appVersion: 1.19.0-20220715214547.db9aedc
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-redfish-translation-service

--- a/charts/v2.0/cray-hms-rts/values.yaml
+++ b/charts/v2.0/cray-hms-rts/values.yaml
@@ -1,6 +1,6 @@
 ---
 global:
-  appVersion: 1.19.0-20220715214547.db9aedc
+  appVersion: 1.20.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-redfish-translation-service
@@ -170,7 +170,7 @@ cray-service:
   volumes:
     default-tls-vol:
       name: default-tls-vol
-      secret: 
+      secret:
         secretName: cray-hms-rts-default-tls
   service:
     type: ClusterIP

--- a/charts/v2.0/cray-hms-rts/values.yaml
+++ b/charts/v2.0/cray-hms-rts/values.yaml
@@ -121,6 +121,9 @@ cray-service:
             configMapKeyRef:
               name: cray-rts-config
               key: cray-hms-rts.jaws_polling_workers
+      volumeMounts:
+        - name: default-tls-vol
+          mountPath: /default-tls/
       ports:
         - name: http
           containerPort: 8082
@@ -164,6 +167,11 @@ cray-service:
         runAsUser: 999
         runAsGroup: 1000
         runAsNonRoot: true
+  volumes:
+    default-tls-vol:
+      name: default-tls-vol
+      secret: 
+        secretName: cray-hms-rts-default-tls
   service:
     type: ClusterIP
     ports:
@@ -212,8 +220,8 @@ environment:
     vault_skip_verify: "true"
     hms_vault_keypath: "secret/hms-creds"
     hsm_url: "http://cray-smd"
-    https_cert: "configs/rts.crt"
-    https_key: "configs/rts.key"
+    https_cert: "/default-tls/tls.crt"
+    https_key: "/default-tls/tls.key"
     collector_url: "http://cray-hms-hmcollector-ingress"
     backend_helper: "JAWS"
     rts_dns_provider: "k8s_service"


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
- Removed hardcoded certificate from RTS container image.
- Use cert-manager to generate the default HTTPs certificate for RTS.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
Backwards compatible.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMHMS-5607](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5607)

## Testing

_List the environments in which these changes were tested._

Tested on:

  * Mug
  * VShasta

Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Yes
- Was downgrade tested? If not, why? Yes

For testing see: https://github.com/Cray-HPE/hms-redfish-translation-layer/pull/41

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
Low risk.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable