### PR TITLE
VSHA-267 Changes to RTS values.yaml to make RTS work on vShasta

### DIFF
--- a/changelog/v3.0.md
+++ b/changelog/v3.0.md
@@ -5,6 +5,10 @@ All notable changes to this project for v3.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.2] - 2023-05-19
+### Changed
+- Add secret to allow RTS to talk to the GCP apis to discover nodes in vShasta
+
 
 ## [3.0.1] - 2023-05-15
 

--- a/charts/v3.0/cray-hms-rts/Chart.yaml
+++ b/charts/v3.0/cray-hms-rts/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-rts"
-version: 3.0.1
+version: 3.0.2
 description: "Kubernetes resources for cray-hms-rts"
 home: "https://github.com/Cray-HPE/hms-rts-charts"
 sources:
@@ -8,6 +8,6 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 1.22.0
+appVersion: 1.23.0
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v3.0/cray-hms-rts/templates/deployment.yaml
+++ b/charts/v3.0/cray-hms-rts/templates/deployment.yaml
@@ -93,6 +93,8 @@ spec:
           volumeMounts:
             - name: default-tls-vol
               mountPath: /default-tls/
+            - name: google-sa-key
+              mountPath: /.config/gcloud
           resources:
             {{- .Values.rtsConfig.resources | toYaml | nindent 12 }}
           securityContext:
@@ -141,3 +143,10 @@ spec:
         - name: default-tls-vol
           secret:
             secretName: {{ .Release.Name | default .Values.rtsDefaultName }}-default-tls
+        - name:  google-sa-key
+          secret:
+            secretName: rts-serviceaccount-key
+            optional: true
+            items:
+            - key: key.json
+              path: application_default_credentials.json

--- a/charts/v3.0/cray-hms-rts/values.yaml
+++ b/charts/v3.0/cray-hms-rts/values.yaml
@@ -1,6 +1,6 @@
 ---
 global:
-  appVersion: 1.22.0
+  appVersion: 1.23.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-redfish-translation-service

--- a/cray-hms-rts.compatibility.yaml
+++ b/cray-hms-rts.compatibility.yaml
@@ -17,6 +17,7 @@ chartVersionToApplicationVersion:
   "2.0.4": "1.20.0"
   "3.0.0": "1.21.0"
   "3.0.1": "1.22.0"
+  "3.0.2": "1.23.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Restore chart settings from the distant past that make it possible to enable Google mode for RTS to allow it to work on Virtual Shasta. Specifically, this adds a volume mount to the cray-hms-rts container that places the GCP service account credentials in the right place for RTS to use them in Google mode. The volume is defined as optional, so, if the underlying secret is not present it will be mounted as an empty directory.

This is a backward compatible change.

## Issues and Related PRs

* Relates to [VSHA-267](https://jira-pro.its.hpecorp.net:8443/browse/VSHA-267)

## Testing

Tested on:

  * Virtual Shasta

Test description:

Deployed chart with appropriate overrides in customizations.yaml and verified that the resulting RTS came up using the Google helpers and discovered nodes. Deployed the same chart without the customizations.yaml overrides and verified that RTS came up as it has in the past on vShasta.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? y
- Were continuous integration tests run? If not, why? n
- Was upgrade tested? If not, why? N/A
- Was downgrade tested? If not, why? N/A


## Risks and Mitigations

There are no known risks associated with this change.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable