### PR TITLE
Fix RTS creating Kubernetes Service entries using the incorrect selector labels

### DIFF
--- a/changelog/v3.0.md
+++ b/changelog/v3.0.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [3.0.1] - 2023-05-15
+
+### Fixed
+
+- RTS creating Kubernetes Service entries using the incorrect selector labels.
+
 ## [3.0.0] - 2023-05-03
 
 ### Changed

--- a/charts/v3.0/cray-hms-rts/Chart.yaml
+++ b/charts/v3.0/cray-hms-rts/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-rts"
-version: 3.0.0
+version: 3.0.1
 description: "Kubernetes resources for cray-hms-rts"
 home: "https://github.com/Cray-HPE/hms-rts-charts"
 sources:
@@ -8,6 +8,6 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 1.21.0
+appVersion: 1.22.0
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v3.0/cray-hms-rts/templates/deployment.yaml
+++ b/charts/v3.0/cray-hms-rts/templates/deployment.yaml
@@ -70,6 +70,8 @@ spec:
               value: "{{ .Values.environment.cray_hms_rts.jaws_polling_humidity_interval }}"
             - name: JAWS_POLLING_WORKERS
               value: "{{ .Values.environment.cray_hms_rts.jaws_polling_workers }}"
+            - name: POD_NAME
+              value: "{{ .Release.Name | default .Values.rtsDefaultName }}"
           ports:
             - name: http
               containerPort: 8082

--- a/charts/v3.0/cray-hms-rts/templates/rbac.yaml
+++ b/charts/v3.0/cray-hms-rts/templates/rbac.yaml
@@ -61,7 +61,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["services"]
-    verbs: ["get", "create"]
+    verbs: ["get", "create", "delete"]
   - apiGroups: ["", "batch"]
     resources: ["jobs"]
     verbs: ["get", "list"]

--- a/charts/v3.0/cray-hms-rts/values.yaml
+++ b/charts/v3.0/cray-hms-rts/values.yaml
@@ -1,6 +1,6 @@
 ---
 global:
-  appVersion: 1.21.0
+  appVersion: 1.22.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-redfish-translation-service

--- a/cray-hms-rts.compatibility.yaml
+++ b/cray-hms-rts.compatibility.yaml
@@ -16,6 +16,7 @@ chartVersionToApplicationVersion:
   "2.0.3": "1.19.0"
   "2.0.4": "1.20.0"
   "3.0.0": "1.21.0"
+  "3.0.1": "1.22.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

RTS runs with separate instances for different backends but was creating kubernetes DNS entries that all went to one pod. This mod adds the POD_NAME environment variable so the kubernetes pod name can be passed in for use with the informDNS() functions.

## Issues and Related PRs

* Resolves [CASMTRIAGE-5352](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5352)

## Testing

For testing, see https://github.com/Cray-HPE/hms-redfish-translation-layer/pull/47

## Risks and Mitigations

None


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable