### PR TITLE
Update cert-manager version for k8s 1.22 upgrade

### DIFF
--- a/.github/workflows/k8s_api_checker.yaml
+++ b/.github/workflows/k8s_api_checker.yaml
@@ -4,8 +4,3 @@ jobs:
   k8s_api_checker:
     uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/k8s_api_checker.yaml@v2
     secrets: inherit
-    with:
-      # ignore-errors can be removed once the deprecated APIs are updated.
-      # Setting this to true causes the workflow to always complete as a success
-      # however the reports are still generated.
-      ignore-errors: true

--- a/changelog/v4.0.md
+++ b/changelog/v4.0.md
@@ -1,6 +1,6 @@
 # Changelog for v4.0
 
-All notable changes to this project for v3.0.Z will be documented in this file.
+All notable changes to this project for v4.0.Z will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/changelog/v4.0.md
+++ b/changelog/v4.0.md
@@ -1,0 +1,13 @@
+# Changelog for v4.0
+
+All notable changes to this project for v3.0.Z will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## [4.0.0] - 2023-05-10
+
+### Changed
+
+- Updated cert-manager

--- a/charts/v4.0/cray-hms-rts/.gitignore
+++ b/charts/v4.0/cray-hms-rts/.gitignore
@@ -1,0 +1,5 @@
+# by default we'll ignore any subcharts included, but simply adjust this if need be
+charts/*
+helm/*
+# Ignore also any built charts
+*.tgz

--- a/charts/v4.0/cray-hms-rts/Chart.yaml
+++ b/charts/v4.0/cray-hms-rts/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: "cray-hms-rts"
+version: 4.0.0
+description: "Kubernetes resources for cray-hms-rts"
+home: "https://github.com/Cray-HPE/hms-rts-charts"
+sources:
+  - "https://github.com/Cray-HPE/hms-redfish-translation-layer"
+maintainers:
+  - name: Hardware Management
+    url: https://github.com/orgs/Cray-HPE/teams/hardware-management
+appVersion: 1.23.0
+annotations:
+  artifacthub.io/license: "MIT"

--- a/charts/v4.0/cray-hms-rts/templates/certificate.yaml
+++ b/charts/v4.0/cray-hms-rts/templates/certificate.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Release.Name | default .Values.rtsDefaultName }}-default-tls
+spec:
+  commonName: {{ .Release.Name | default .Values.rtsDefaultName }}
+  dnsNames:
+  - {{ .Release.Name | default .Values.rtsDefaultName }}.services.cluster.svc.local
+  - {{ .Release.Name | default .Values.rtsDefaultName }}.services.cluster.svc
+  - {{ .Release.Name | default .Values.rtsDefaultName }}.services
+  duration: 720h0m0s
+  issuerRef:
+    kind: Issuer
+    name: cert-manager-issuer-common
+  keyAlgorithm: rsa
+  keyEncoding: pkcs1
+  keySize: 2048
+  renewBefore: 24h0m0s
+  secretName: {{ .Release.Name | default .Values.rtsDefaultName }}-default-tls

--- a/charts/v4.0/cray-hms-rts/templates/certificate.yaml
+++ b/charts/v4.0/cray-hms-rts/templates/certificate.yaml
@@ -13,8 +13,9 @@ spec:
   issuerRef:
     kind: Issuer
     name: cert-manager-issuer-common
-  keyAlgorithm: rsa
-  keyEncoding: pkcs1
-  keySize: 2048
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 2048
   renewBefore: 24h0m0s
   secretName: {{ .Release.Name | default .Values.rtsDefaultName }}-default-tls

--- a/charts/v4.0/cray-hms-rts/templates/deployment.yaml
+++ b/charts/v4.0/cray-hms-rts/templates/deployment.yaml
@@ -1,0 +1,152 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name | default .Values.rtsDefaultName }}
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name | default .Values.rtsDefaultName }}
+spec:
+  replicas: {{ .Values.rtsConfig.replicas }}
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 50%
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Release.Name | default .Values.rtsDefaultName }}
+      app.kubernetes.io/instance: {{ .Release.Name | default .Values.rtsDefaultName }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Release.Name | default .Values.rtsDefaultName }}
+        app.kubernetes.io/instance: {{ .Release.Name | default .Values.rtsDefaultName }}
+      annotations:
+        traffic.sidecar.istio.io/excludeOutboundPorts: "8082,9092,2181"
+        {{- if .Values.podAnnotations }}
+        {{- .Values.podAnnotations | toYaml | nindent 8 -}}
+        {{- end }}
+    spec:
+      serviceAccountName: "{{ .Release.Name | default .Values.rtsDefaultName }}-dispatcher"
+      containers:
+        - name: "cray-hms-rts"
+          image: {{ .Values.image.repository }}:{{ default .Values.global.appVersion .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: LOG_LEVEL
+              value: "{{ .Values.environment.cray_hms_rts.log_level }}"
+            - name: RF_MSG_HOST
+              value: "{{ .Values.environment.cray_hms_rts.rf_msg_host }}"
+            - name: VAULT_ADDR
+              value: "{{ .Values.environment.cray_hms_rts.vault_addr }}"
+            - name: HMS_VAULT_KEYPATH
+              value: "{{ .Values.environment.cray_hms_rts.hms_vault_keypath }}"
+            - name: VAULT_SKIP_VERIFY
+              value: "{{ .Values.environment.cray_hms_rts.vault_skip_verify }}"
+            - name: HSM_URL
+              value: "{{ .Values.environment.cray_hms_rts.hsm_url }}"
+            - name: SLS_URL
+              value: "{{ .Values.environment.cray_hms_rts.sls_url }}"
+            - name: HTTPS_CERT
+              value: "{{ .Values.environment.cray_hms_rts.https_cert }}"
+            - name: HTTPS_KEY
+              value: "{{ .Values.environment.cray_hms_rts.https_key }}"
+            - name: COLLECTOR_URL
+              value: "{{ .Values.environment.cray_hms_rts.collector_url }}"
+            - name: BACKEND_HELPER
+              value: "{{ .Values.environment.cray_hms_rts.backend_helper }}"
+            - name: RTS_DNS_PROVIDER
+              value: "{{ .Values.environment.cray_hms_rts.rts_dns_provider }}"
+            - name: CERTIFICATE_VAULT_KEYPATH
+              value: "{{ .Values.environment.cray_hms_rts.certificate_vault_keypath }}"
+            - name: JAWS_VAULT_KEYPATH
+              value: "{{ .Values.environment.cray_hms_rts.jaws_vault_keypath }}"
+            - name: JAWS_POLLING_ENABLED
+              value: "{{ .Values.environment.cray_hms_rts.jaws_polling_enabled }}"
+            - name: JAWS_POLLING_INTERVAL
+              value: "{{ .Values.environment.cray_hms_rts.jaws_polling_interval }}"
+            - name: JAWS_POLLING_TEMPERATURE_INTERVAL
+              value: "{{ .Values.environment.cray_hms_rts.jaws_polling_temperature_interval }}"
+            - name: JAWS_POLLING_HUMIDITY_INTERVAL
+              value: "{{ .Values.environment.cray_hms_rts.jaws_polling_humidity_interval }}"
+            - name: JAWS_POLLING_WORKERS
+              value: "{{ .Values.environment.cray_hms_rts.jaws_polling_workers }}"
+            - name: POD_NAME
+              value: "{{ .Release.Name | default .Values.rtsDefaultName }}"
+          ports:
+            - name: http
+              containerPort: 8082
+            - name: https
+              containerPort: 8083
+          livenessProbe:
+            httpGet:
+              port: 8082
+              path: /healthz
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              port: 8082
+              path: /healthz
+              scheme: HTTP
+            initialDelaySeconds: 5
+          volumeMounts:
+            - name: default-tls-vol
+              mountPath: /default-tls/
+            - name: google-sa-key
+              mountPath: /.config/gcloud
+          resources:
+            {{- .Values.rtsConfig.resources | toYaml | nindent 12 }}
+          securityContext:
+            runAsUser: 65534
+            runAsGroup: 65534
+            runAsNonRoot: true
+        - name: "cray-hms-rts-redis"
+          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          imagePullPolicy: "{{ .Values.redis.image.pullPolicy }}"
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - redis-cli PING
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - redis-cli PING
+            initialDelaySeconds: 1
+            periodSeconds: 5
+          securityContext:
+            runAsUser: 999
+            runAsGroup: 1000
+            runAsNonRoot: true
+      initContainers:
+        - name: "wait-for-cray-hms-rts-init"
+          env:
+            - name: DONT_WAIT
+              value: "{{ .Values.environment.wait_for_cray_hms_rts_init.dont_wait }}"
+          image: "{{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}"
+          imagePullPolicy: {{ .Values.kubectl.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - while [ -z "$DONT_WAIT" -a "`kubectl get jobs -n services cray-hms-rts-init -o jsonpath='{.status.conditions[0].type}'`" != "Complete" ]; do echo "Waiting for cray-hms-rts-init to complete"; sleep 3;  done; echo "Completed";
+          securityContext:
+            runAsUser: 65534
+            runAsGroup: 65534
+            runAsNonRoot: true
+      volumes:
+        - name: default-tls-vol
+          secret:
+            secretName: {{ .Release.Name | default .Values.rtsDefaultName }}-default-tls
+        - name:  google-sa-key
+          secret:
+            secretName: rts-serviceaccount-key
+            optional: true
+            items:
+            - key: key.json
+              path: application_default_credentials.json

--- a/charts/v4.0/cray-hms-rts/templates/destinationrules.yaml
+++ b/charts/v4.0/cray-hms-rts/templates/destinationrules.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "{{ .Release.Name | default .Values.rtsDefaultName }}-sma-kafkarule"
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name | default .Values.rtsDefaultName }}
+spec:
+  host: "cluster-kafka-bootstrap.sma.svc.cluster.local"
+  trafficPolicy:
+    tls:
+      mode: DISABLE
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "{{ .Release.Name | default .Values.rtsDefaultName }}-sma-collectorrule"
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name | default .Values.rtsDefaultName }}
+spec:
+  host: "hms-hmcollector.sma.svc.cluster.local"
+  trafficPolicy:
+    tls:
+      mode: DISABLE
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "{{ .Release.Name | default .Values.rtsDefaultName }}-service"
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name | default .Values.rtsDefaultName }}
+spec:
+  host: "{{ .Release.Name | default .Values.rtsDefaultName }}"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL

--- a/charts/v4.0/cray-hms-rts/templates/hook-serviceaccount.yaml
+++ b/charts/v4.0/cray-hms-rts/templates/hook-serviceaccount.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.rtsDoInit }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name | default .Values.rtsDefaultName }}
+  namespace: services
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name | default .Values.rtsDefaultName }}
+  namespace: services
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+rules:
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name | default .Values.rtsDefaultName }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name | default .Values.rtsDefaultName }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name | default .Values.rtsDefaultName }}
+    namespace: services
+{{- end }}

--- a/charts/v4.0/cray-hms-rts/templates/jobs.yaml
+++ b/charts/v4.0/cray-hms-rts/templates/jobs.yaml
@@ -1,0 +1,68 @@
+{{- if .Values.rtsDoInit }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cray-hms-rts-init-deleter
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "0"
+spec:
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: “false”
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: "{{ .Release.Name | default .Values.rtsDefaultName }}"
+      containers:
+        - name: job-deleter
+          image: "{{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}"
+          imagePullPolicy: "{{ .Values.kubectl.image.pullPolicy }}"
+          command:
+          - /bin/sh
+          - -c
+          - set -x;
+            echo "Deleting Jobs";
+            kubectl -n services delete job cray-hms-rts-init;
+            exit 0
+---
+apiVersion: batch/v1
+kind:       Job
+metadata:
+  name: cray-hms-rts-init
+  labels:
+    app: cray-hms-rts-init
+spec:
+  template:
+    metadata:
+      labels:
+        app: cray-hms-rts-init
+    spec:
+      serviceAccountName: "{{ .Release.Name | default .Values.rtsDefaultName }}-vault-watcher"
+      restartPolicy: OnFailure
+      containers:
+        - name: cray-hms-rts-init
+          env:
+            - name:  VAULT_ADDR
+              value: "{{ .Values.environment.cray_hms_rts.vault_addr }}"
+            - name:  VAULT_SKIP_VERIFY
+              value: "{{ .Values.environment.cray_hms_rts.vault_skip_verify }}"
+            - name:  VAULT_RTS_MAX_CONNECTION_ATTEMPTS
+              value: "120"
+            - name: VAULT_RTS_DEFAULT_CREDENTIALS
+              valueFrom:
+                secretKeyRef:
+                  name: cray-hms-rts-credentials
+                  key: vault_rts_defaults
+            - name: VAULT_PDU_DEFAULT_CREDENTIALS
+              valueFrom:
+                secretKeyRef:
+                  name: cray-hms-rts-credentials
+                  key: vault_pdu_defaults
+            - name: JAWS_VAULT_KEYPATH
+              value: "{{ .Values.environment.cray_hms_rts.jaws_vault_keypath }}"
+          image: "{{ .Values.image.repository }}:{{ default .Values.global.appVersion .Values.image.tag }}"
+          command: ["vault_loader"]
+{{- end }}

--- a/charts/v4.0/cray-hms-rts/templates/rbac.yaml
+++ b/charts/v4.0/cray-hms-rts/templates/rbac.yaml
@@ -1,0 +1,72 @@
+{{- if .Values.rtsDoInit }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name | default .Values.rtsDefaultName }}-vault-watcher-crb
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name | default .Values.rtsDefaultName }}-vault-watcher
+    namespace: services
+roleRef:
+  kind: ClusterRole
+  name: {{ .Release.Name | default .Values.rtsDefaultName }}-vault-watcher-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: services
+  name: {{ .Release.Name | default .Values.rtsDefaultName }}-vault-watcher
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name | default .Values.rtsDefaultName }}-vault-watcher-role
+rules:
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    resourceNames: ["cray-vault"]
+    verbs: ["get"]
+  - apiGroups: ['policy']
+    resources: ['podsecuritypolicies']
+    verbs:     ['use']
+    resourceNames:
+    - restricted-transition-net-raw
+{{- end }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name | default .Values.rtsDefaultName }}-dispatcher-crb
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name | default .Values.rtsDefaultName }}-dispatcher
+    namespace: services
+roleRef:
+  kind: ClusterRole
+  name: {{ .Release.Name | default .Values.rtsDefaultName }}-dispatcher-cr
+  apiGroup: ""
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: services
+  name: {{ .Release.Name | default .Values.rtsDefaultName }}-dispatcher
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name | default .Values.rtsDefaultName }}-dispatcher-cr
+rules:
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "create", "delete"]
+  - apiGroups: ["", "batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list"]
+  - apiGroups: ['policy']
+    resources: ['podsecuritypolicies']
+    verbs:     ['use']
+    resourceNames:
+    - restricted-transition-net-raw

--- a/charts/v4.0/cray-hms-rts/templates/sealedsecrets.yaml
+++ b/charts/v4.0/cray-hms-rts/templates/sealedsecrets.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.rtsDoInit }}
+{{- if index .Values "cray-service" "sealedSecrets" -}}
+{{- range $val := index .Values "cray-service" "sealedSecrets" }}
+{{- if $val.kind }}
+{{- if eq $val.kind "SealedSecret" }}
+---
+{{ toYaml $val }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end }}

--- a/charts/v4.0/cray-hms-rts/templates/service.yaml
+++ b/charts/v4.0/cray-hms-rts/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name | default .Values.rtsDefaultName }}
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name | default .Values.rtsDefaultName }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      name: http
+      protocol: TCP
+      targetPort: http
+    - port: 443
+      name: https
+      protocol: TCP
+      targetPort: https
+  selector:
+    app.kubernetes.io/name: {{ .Release.Name | default .Values.rtsDefaultName }}

--- a/charts/v4.0/cray-hms-rts/values.yaml
+++ b/charts/v4.0/cray-hms-rts/values.yaml
@@ -1,0 +1,69 @@
+---
+global:
+  appVersion: 1.23.0
+
+image:
+  repository: artifactory.algol60.net/csm-docker/stable/hms-redfish-translation-service
+  pullPolicy: IfNotPresent
+
+kubectl:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
+    tag: 1.19.15
+    pullPolicy: IfNotPresent
+
+redis:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/docker.io/library/redis
+    tag: 5.0-alpine
+    pullPolicy: IfNotPresent
+
+podAnnotations: {}
+# For example, override the default Istio sidecar proxy memory limit:
+# podAnnotations:
+#   sidecar.istio.io/proxyMemoryLimit: 5Gi
+
+rtsDefaultName: "cray-hms-rts"
+rtsDoInit: true
+
+rtsConfig:
+  replicas: 1
+  resources: {}
+
+# We're not using the cray-service chart anymore but this needs to be
+# defined here to pick up the sealed secrets from customizations.yaml
+# and avoid errors if sealedSecrets remains empty.
+cray-service:
+  sealedSecrets: []
+
+# This is where the environment variable defaults are actually set.
+# Override these as needed to adjust for other environments.  For
+# example, you can can say `values.environment.cray_hms_rts.backend_helper: GCloud`
+# in a value override to enable the 'GCloud' backend helper.
+environment:
+  cray_hms_rts:
+    log_level: "INFO"
+    rf_msg_host: "cray-shared-kafka-kafka-bootstrap.services.svc.cluster.local:9092"
+    vault_addr: "http://cray-vault.vault:8200"
+    vault_skip_verify: "true"
+    hms_vault_keypath: "secret/hms-creds"
+    hsm_url: "http://cray-smd"
+    sls_url: "http://cray-sls/v1"
+    https_cert: "/default-tls/tls.crt"
+    https_key: "/default-tls/tls.key"
+    collector_url: "http://cray-hms-hmcollector-ingress"
+    backend_helper: "JAWS"
+    rts_dns_provider: "k8s_service"
+    certificate_vault_keypath: "secret/pdu-creds/certificates"
+
+    # JAWs Backend Helper Configuration
+    jaws_vault_keypath: "secret/pdu-creds"
+    jaws_polling_enabled: true
+    jaws_polling_interval: 10  # Seconds
+    jaws_polling_temperature_interval: 30  # Seconds
+    jaws_polling_humidity_interval: 30  # Seconds
+    jaws_polling_workers: 30
+  wait_for_cray_hms_rts_init:
+    # a non-empty string in the following causes the initContainer to
+    # simply exit successfully and immediately.
+    dont_wait: ""

--- a/cray-hms-rts.compatibility.yaml
+++ b/cray-hms-rts.compatibility.yaml
@@ -4,7 +4,7 @@ chartVersionToCSMVersion:
   # Chart version: CSM version
   ">=2.0.0": "~1.4.0" # Chart Version: 2.0.0 <= x.y.z, CSM Version: 1.2.0 <= x.y.z < 1.3.0
   ">=3.0.0": "~1.4.1"
-  ">=4.0.0": "~1.5.0" # 4.0.0 uses newer version of cert-manager
+  ">=4.0.0": "~1.5.0" # 4.0.0 uses a newer version of cert-manager
 
 # The application version must be compliant to semantic versioning. 
 # If the application makes a backwards incompatible change, then its major version needs to be increment.

--- a/cray-hms-rts.compatibility.yaml
+++ b/cray-hms-rts.compatibility.yaml
@@ -4,6 +4,7 @@ chartVersionToCSMVersion:
   # Chart version: CSM version
   ">=2.0.0": "~1.4.0" # Chart Version: 2.0.0 <= x.y.z, CSM Version: 1.2.0 <= x.y.z < 1.3.0
   ">=3.0.0": "~1.4.1"
+  ">=4.0.0": "~1.5.0" # 4.0.0 uses newer version of cert-manager
 
 # The application version must be compliant to semantic versioning. 
 # If the application makes a backwards incompatible change, then its major version needs to be increment.
@@ -18,6 +19,7 @@ chartVersionToApplicationVersion:
   "3.0.0": "1.21.0"
   "3.0.1": "1.22.0"
   "3.0.2": "1.23.0"
+  "4.0.0": "1.23.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Updated cert-manager version to support kubernetes version 1.22

diff between chart v3.0 and v4.0
```
$ diff -r charts/v3.0/ charts/v4.0/
diff -r charts/v3.0/cray-hms-rts/Chart.yaml charts/v4.0/cray-hms-rts/Chart.yaml
3c3
< version: 3.0.2
---
> version: 4.0.0
diff -r charts/v3.0/cray-hms-rts/templates/certificate.yaml charts/v4.0/cray-hms-rts/templates/certificate.yaml
2c2
< apiVersion: cert-manager.io/v1alpha3
---
> apiVersion: cert-manager.io/v1
16,18c16,19
<   keyAlgorithm: rsa
<   keyEncoding: pkcs1
<   keySize: 2048
---
>   privateKey:
>     algorithm: RSA
>     encoding: PKCS1
>     size: 2048
20c21
<   secretName: {{ .Release.Name | default .Values.rtsDefaultName }}-default-tls
\ No newline at end of file
---
>   secretName: {{ .Release.Name | default .Values.rtsDefaultName }}-default-tls
```


## Issues and Related PRs

* Resolves [CASMHMS-5879](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-5879)

## Testing

Tested on:

  * drax

Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Yes
- Were continuous integration tests run? If not, why? Yes
- Was upgrade tested? If not, why? Yes
- Was downgrade tested? If not, why? Yes


## Risks and Mitigations


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable