### PR TITLE
Add TTL to init yaml to prevent keyverno from deleting the completed job

### DIFF
--- a/changelog/v4.0.md
+++ b/changelog/v4.0.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [4.0.1] - 2023-10-02
+
+### Fixed
+
+- Added ttlSecondsAfterFinished setting to init job yaml
+
 ## [4.0.0] - 2023-05-10
 
 ### Changed

--- a/charts/v4.0/cray-hms-rts/Chart.yaml
+++ b/charts/v4.0/cray-hms-rts/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-rts"
-version: 4.0.0
+version: 4.0.1
 description: "Kubernetes resources for cray-hms-rts"
 home: "https://github.com/Cray-HPE/hms-rts-charts"
 sources:

--- a/charts/v4.0/cray-hms-rts/templates/jobs.yaml
+++ b/charts/v4.0/cray-hms-rts/templates/jobs.yaml
@@ -35,6 +35,7 @@ metadata:
   labels:
     app: cray-hms-rts-init
 spec:
+  ttlSecondsAfterFinished: 2147483647
   template:
     metadata:
       labels:

--- a/cray-hms-rts.compatibility.yaml
+++ b/cray-hms-rts.compatibility.yaml
@@ -20,6 +20,7 @@ chartVersionToApplicationVersion:
   "3.0.1": "1.22.0"
   "3.0.2": "1.23.0"
   "4.0.0": "1.23.0"
+  "4.0.1": "1.23.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

The cray-hms-rts-init job was deleted by keyverno due to its TTL default settings. What this means is that when cray-hms-rts restarts, it will be stuck in init because it is looking for the init job to be competed, but since the init job was removed, cray-hms-rts will be stuck in init. 

## Issues and Related PRs

* Resolves [CASMHMS-6099](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6099)

## Testing

_List the environments in which these changes were tested._

Tested on:

  * `baldar`
  * Local development environment
  * Virtual Shasta

Test description:

Verified the cray-hms-rts-init job contained the new ttl setting.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N - wanted to keep the changes to make sure the job isn't deleted.


## Risks and Mitigations

No known risks

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable