### PR TITLE
Added Time To Live (TTL) setting to the init job

### DIFF
--- a/changelog/v4.0.md
+++ b/changelog/v4.0.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [4.0.1] - 2024-01-16
+
+### Changed
+
+- Added TTL (Time To Live) setting to the init job
+
 ## [4.0.0] - 2023-05-10
 
 ### Changed

--- a/charts/v4.0/cray-hms-rts/Chart.yaml
+++ b/charts/v4.0/cray-hms-rts/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-rts"
-version: 4.0.0
+version: 4.0.1
 description: "Kubernetes resources for cray-hms-rts"
 home: "https://github.com/Cray-HPE/hms-rts-charts"
 sources:

--- a/charts/v4.0/cray-hms-rts/templates/jobs.yaml
+++ b/charts/v4.0/cray-hms-rts/templates/jobs.yaml
@@ -35,6 +35,7 @@ metadata:
   labels:
     app: cray-hms-rts-init
 spec:
+  ttlSecondsAfterFinished: {{ .Values.rtsInitJobTTL }}
   template:
     metadata:
       labels:

--- a/charts/v4.0/cray-hms-rts/values.yaml
+++ b/charts/v4.0/cray-hms-rts/values.yaml
@@ -30,6 +30,8 @@ rtsConfig:
   replicas: 1
   resources: {}
 
+rtsInitJobTTL: 2147483647
+
 # We're not using the cray-service chart anymore but this needs to be
 # defined here to pick up the sealed secrets from customizations.yaml
 # and avoid errors if sealedSecrets remains empty.

--- a/cray-hms-rts.compatibility.yaml
+++ b/cray-hms-rts.compatibility.yaml
@@ -20,6 +20,7 @@ chartVersionToApplicationVersion:
   "3.0.1": "1.22.0"
   "3.0.2": "1.23.0"
   "4.0.0": "1.23.0"
+  "4.0.1": "1.23.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION


## Summary and Scope

Added a very large time to live setting to the rts init job. The large value is 2147483647 (Around 68 years)

## Issues and Related PRs

* Resolves [CASMHMS-6099](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6099)

## Testing

Verified that the hms tests still passed. There aren't any rts specific tests.
Verified that the job gets deleted when the time to live value to a small value (600 for 5 minutes).

Tested on:

  * mug

Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y


## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable