### PR TITLE
CASMTRIAGE-6698: Fixed concurrency issue associated with RedisActivePipeline

### DIFF
--- a/changelog/v4.0.md
+++ b/changelog/v4.0.md
@@ -5,6 +5,11 @@ All notable changes to this project for v4.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.2] - 2024-02-28
+
+### Fixed
+
+- Fixed concurrency issue associated with RedisActivePipeline
 
 ## [4.0.1] - 2024-01-16
 

--- a/charts/v4.0/cray-hms-rts/Chart.yaml
+++ b/charts/v4.0/cray-hms-rts/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-rts"
-version: 4.0.1
+version: 4.0.2
 description: "Kubernetes resources for cray-hms-rts"
 home: "https://github.com/Cray-HPE/hms-rts-charts"
 sources:
@@ -8,6 +8,6 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 1.23.0
+appVersion: 1.24.0
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v4.0/cray-hms-rts/values.yaml
+++ b/charts/v4.0/cray-hms-rts/values.yaml
@@ -1,6 +1,6 @@
 ---
 global:
-  appVersion: 1.23.0
+  appVersion: 1.24.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-redfish-translation-service

--- a/cray-hms-rts.compatibility.yaml
+++ b/cray-hms-rts.compatibility.yaml
@@ -21,6 +21,7 @@ chartVersionToApplicationVersion:
   "3.0.2": "1.23.0"
   "4.0.0": "1.23.0"
   "4.0.1": "1.23.0"
+  "4.0.2": "1.24.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

In snmpSwitch.go:RunPeriodic() we construct a list of all network switches and spawn off Go routines for each them.  Every one of these Go routines calls into helper.initDevice() to initialize the network switch.  In this function, they use a shared helper.RedisHelper.RedisActivePipeline variable to create a Redis pipeline.  At the end of its use it is reset to nil.  This opens a race condition resulting in a potential bad pointer dereference.

The fix here is to protect the use of helper.RedisHelper.RedisActivePipeline with a mutex, serialized access to the Redis pipeline.

Adopted app version 4.0.2

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMTRIAGE-6698
* Change will be needed in:  CSM 1.6 and CSM 1.5.1

## Testing

These changes were rolled out and tested on venado.

Tested on:

  * venado

Test description:

Redeploy cray-hms-rts-snmp pod and verify elimination of seg fault.

- Were continuous integration tests run? Y (via pushed changes to GitHub)
- Was upgrade tested? Y (on venado)
- Was downgrade tested? Y (on venado)

## Pull Request Checklist

- [ x] Version number(s) incremented, if applicable
- [ x] Copyrights updated
- [ x] License file intact
- [ x] Target branch correct
- [ x] CHANGELOG.md updated
- [ x] Testing is appropriate and complete, if applicable