### PR TITLE
CASMHMS-6324: Added support for ppprof builds

### DIFF
--- a/changelog/v5.0.md
+++ b/changelog/v5.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v5.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.2] - 2025-01-08
+
+### Added
+
+- Added support for ppprof builds
+
 ## [5.0.1] - 2024-12-09
 
 ### Changed

--- a/charts/v5.0/cray-hms-rts/Chart.yaml
+++ b/charts/v5.0/cray-hms-rts/Chart.yaml
@@ -8,6 +8,9 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 1.26.0
+appVersion: 1.26.0  # update pprof image version below as well
 annotations:
+  artifacthub.io/images: |-
+    - name: hms-redfish-translation-service-pprof
+      image: artifactory.algol60.net/csm-docker/stable/hms-redfish-translation-service-pprof:1.26.0
   artifacthub.io/license: "MIT"

--- a/charts/v5.0/cray-hms-rts/Chart.yaml
+++ b/charts/v5.0/cray-hms-rts/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-rts"
-version: 5.0.1
+version: 5.0.2
 description: "Kubernetes resources for cray-hms-rts"
 home: "https://github.com/Cray-HPE/hms-rts-charts"
 sources:
@@ -8,6 +8,6 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 1.25.0
+appVersion: 1.26.0
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v5.0/cray-hms-rts/values.yaml
+++ b/charts/v5.0/cray-hms-rts/values.yaml
@@ -1,6 +1,6 @@
 ---
 global:
-  appVersion: 1.25.0
+  appVersion: 1.26.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-redfish-translation-service

--- a/cray-hms-rts.compatibility.yaml
+++ b/cray-hms-rts.compatibility.yaml
@@ -32,6 +32,7 @@ chartVersionToApplicationVersion:
   "4.0.2": "1.24.0"
   "5.0.0": "1.24.0"
   "5.0.1": "1.25.0"
+  "5.0.2": "1.26.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Added support for building a pprof enabled image.  Profiling adds runtime overhead so the pprof enabled image is not used by default.  It is meant to be a debug tool.  In order to use the enabled pprof image, edit the deployment and append "-pprof" to the image name.  For unstable developer builds, be sure to change the built timestamp as well.

Adopted app version 1.26.0 for CSM 1.6.1 (helm chart 5.0.2)

## Issues and Related PRs

* Resolves [CASMHMS-6324](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6324)

## Testing

Tested on:

  * `mug`

Test description:

- Deployed service with pprof enabled - confirmed pprof functionality
- Deployed services with pprof disabled - confirmed pprof support not built into binary
- Functional tests (if they exist) was successfully ran with and without pprof enabled

Test Checklist:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable