### PR TITLE
CASMHMS-6358: Add pprof image support

### DIFF
--- a/changelog/v5.1.md
+++ b/changelog/v5.1.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Removed pprof support in production images
-- Added pprof support in pprof images
+- Removed pprof support in production image
+- Added pprof support in pprof image
 
 ## [5.1.1] - 2025-04-01
 

--- a/changelog/v5.1.md
+++ b/changelog/v5.1.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added pprof image support
+- Removed pprof support in production images
+- Added pprof support in pprof images
 
 ## [5.1.1] - 2025-04-01
 

--- a/changelog/v5.1.md
+++ b/changelog/v5.1.md
@@ -5,7 +5,7 @@ All notable changes to this project for v5.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.1.2] - 2025-04-03
+## [5.1.2] - 2025-04-04
 
 ### Added
 

--- a/changelog/v5.1.md
+++ b/changelog/v5.1.md
@@ -5,6 +5,12 @@ All notable changes to this project for v5.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.2] - 2025-04-03
+
+### Added
+
+- Added pprof image support
+
 ## [5.1.1] - 2025-04-01
 
 ### Security

--- a/charts/v5.1/cray-hms-rts/Chart.yaml
+++ b/charts/v5.1/cray-hms-rts/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-rts"
-version: 5.1.1
+version: 5.1.2
 description: "Kubernetes resources for cray-hms-rts"
 home: "https://github.com/Cray-HPE/hms-rts-charts"
 sources:
@@ -8,6 +8,9 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 1.26.0
+appVersion: 1.27.0
 annotations:
+  artifacthub.io/images: |-
+    - name: cray-rts-pprof
+      image: artifactory.algol60.net/csm-docker/stable/cray-rts-pprof:1.27.0
   artifacthub.io/license: "MIT"

--- a/charts/v5.1/cray-hms-rts/Chart.yaml
+++ b/charts/v5.1/cray-hms-rts/Chart.yaml
@@ -11,6 +11,6 @@ maintainers:
 appVersion: 1.27.0
 annotations:
   artifacthub.io/images: |-
-    - name: cray-rts-pprof
-      image: artifactory.algol60.net/csm-docker/stable/cray-rts-pprof:1.27.0
+    - name: hms-redfish-translation-service-pprof
+      image: artifactory.algol60.net/csm-docker/stable/hms-redfish-translation-service-pprof:1.27.0
   artifacthub.io/license: "MIT"

--- a/charts/v5.1/cray-hms-rts/values.yaml
+++ b/charts/v5.1/cray-hms-rts/values.yaml
@@ -1,6 +1,6 @@
 ---
 global:
-  appVersion: 1.26.0
+  appVersion: 1.27.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-redfish-translation-service

--- a/cray-hms-rts.compatibility.yaml
+++ b/cray-hms-rts.compatibility.yaml
@@ -36,6 +36,7 @@ chartVersionToApplicationVersion:
   "5.0.1": "1.25.0"
   "5.1.0": "1.25.0"
   "5.1.1": "1.26.0"
+  "5.1.2": "1.27.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Removed pprof support in the production image as its generally not advisable.  Created new pprof image to provide this support, consistent with how we enable pprof for our other HMS services.

Adopted app version 1.27.0 for CSM 1.7.0 (helm chart 5.1.2)

### Issues and Related PRs

* Resolves [CASMHMS-6358](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6358)

### Testing

Verified production image no longer contains pprof functionality.

Verified pprof image functions correctly by using a pprof client from my laptop.

Verified no apparent issues in the output logs with both the production and pprof images running.

Tested on:

* `mug`

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Y
Were continuous integration tests run? Y/N   If not, Why? Y
Was an Upgrade tested?                 Y/N   If not, Why? Y 
Was a Downgrade tested?                Y/N   If not, Why? Y 

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable