### PR TITLE
CASMHMS-6477: Fixed various concurrency issues

### DIFF
--- a/changelog/v4.0.md
+++ b/changelog/v4.0.md
@@ -5,11 +5,15 @@ All notable changes to this project for v4.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.0.3] - 2025-04-09
+## [4.0.3] - 2025-04-10
 
 ### Fixed
 
-- Fixed various concurrency issues
+Fixed various concurrency issues:
+
+- Added mutex to protect the KnownDevices map from concurrent writes
+- Extended use of the Redis active pipeline mutex into the gcloud, JAWS,
+  and simulator backend helpers
 
 ## [4.0.2] - 2024-02-28
 

--- a/changelog/v4.0.md
+++ b/changelog/v4.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v4.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.3] - 2025-04-09
+
+### Fixed
+
+- Fixed various concurrency issues
+
 ## [4.0.2] - 2024-02-28
 
 ### Fixed

--- a/changelog/v5.0.md
+++ b/changelog/v5.0.md
@@ -5,11 +5,15 @@ All notable changes to this project for v5.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.0.2] - 2025-04-16
+## [5.0.2] - 2025-04-10
 
 ### Fixed
 
-- Fixed concurrency issue associated with map writes
+Fixed various concurrency issues:
+
+- Added mutex to protect the KnownDevices map from concurrent writes
+- Extended use of the Redis active pipeline mutex into the gcloud, JAWS,
+  and simulator backend helpers
 
 ## [5.0.1] - 2024-12-09
 

--- a/changelog/v5.0.md
+++ b/changelog/v5.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v5.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.2] - 2025-04-16
+
+### Fixed
+
+- Fixed concurrency issue associated with map writes
+
 ## [5.0.1] - 2024-12-09
 
 ### Changed

--- a/changelog/v5.1.md
+++ b/changelog/v5.1.md
@@ -5,11 +5,15 @@ All notable changes to this project for v5.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.1.3] - 2025-04-16
+## [5.1.3] - 2025-04-10
 
 ### Fixed
 
-- Fixed concurrency issue associated with map writes
+Fixed various concurrency issues:
+
+- Added mutex to protect the KnownDevices map from concurrent writes
+- Extended use of the Redis active pipeline mutex into the gcloud, JAWS,
+  and simulator backend helpers
 
 ## [5.1.2] - 2025-04-04
 

--- a/changelog/v5.1.md
+++ b/changelog/v5.1.md
@@ -5,6 +5,12 @@ All notable changes to this project for v5.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.3] - 2025-04-16
+
+### Fixed
+
+- Fixed concurrency issue associated with map writes
+
 ## [5.1.2] - 2025-04-04
 
 ### Added

--- a/charts/v4.0/cray-hms-rts/Chart.yaml
+++ b/charts/v4.0/cray-hms-rts/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-rts"
-version: 4.0.2
+version: 4.0.3
 description: "Kubernetes resources for cray-hms-rts"
 home: "https://github.com/Cray-HPE/hms-rts-charts"
 sources:
@@ -8,6 +8,6 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 1.24.0
+appVersion: 1.24.1
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v4.0/cray-hms-rts/values.yaml
+++ b/charts/v4.0/cray-hms-rts/values.yaml
@@ -1,6 +1,6 @@
 ---
 global:
-  appVersion: 1.24.0
+  appVersion: 1.24.1
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-redfish-translation-service

--- a/charts/v5.0/cray-hms-rts/Chart.yaml
+++ b/charts/v5.0/cray-hms-rts/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-rts"
-version: 5.0.1
+version: 5.0.2
 description: "Kubernetes resources for cray-hms-rts"
 home: "https://github.com/Cray-HPE/hms-rts-charts"
 sources:
@@ -8,6 +8,6 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 1.25.0
+appVersion: 1.25.1
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v5.0/cray-hms-rts/values.yaml
+++ b/charts/v5.0/cray-hms-rts/values.yaml
@@ -1,6 +1,6 @@
 ---
 global:
-  appVersion: 1.25.0
+  appVersion: 1.25.1
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-redfish-translation-service

--- a/charts/v5.1/cray-hms-rts/Chart.yaml
+++ b/charts/v5.1/cray-hms-rts/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-rts"
-version: 5.1.2
+version: 5.1.3
 description: "Kubernetes resources for cray-hms-rts"
 home: "https://github.com/Cray-HPE/hms-rts-charts"
 sources:
@@ -8,7 +8,7 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: 1.27.0
+appVersion: 1.28.0
 annotations:
   artifacthub.io/images: |-
     - name: hms-redfish-translation-service-pprof

--- a/charts/v5.1/cray-hms-rts/values.yaml
+++ b/charts/v5.1/cray-hms-rts/values.yaml
@@ -1,6 +1,6 @@
 ---
 global:
-  appVersion: 1.27.0
+  appVersion: 1.28.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-redfish-translation-service

--- a/cray-hms-rts.compatibility.yaml
+++ b/cray-hms-rts.compatibility.yaml
@@ -32,11 +32,14 @@ chartVersionToApplicationVersion:
   "4.0.0": "1.23.0"
   "4.0.1": "1.23.0"
   "4.0.2": "1.24.0"
+  "4.0.3": "1.24.1"
   "5.0.0": "1.24.0"
   "5.0.1": "1.25.0"
+  "5.0.2": "1.25.1"
   "5.1.0": "1.25.0"
   "5.1.1": "1.26.0"
   "5.1.2": "1.27.0"
+  "5.1.3": "1.28.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

There are several concurrency related changes in this PR.

A lock was added to protect the `KnownDevice` map from concurrent writes.  This was the original bug described in CASMHMS-6477.  Seperate mutexes were added for the certificate service and both the SNMP and JAWS backend helpers.  This was because there is a uniqe `KnownDevice` map for each of them.

Renamed `redisActivePipelineMux` to `RedisActivePipelineMux` and moved it into the `RedisHelper` struct so that it could be more widely accessed.  It was previously used only in the SNMP backend helper to protect the Redis active pipeline from oncurrent writes.  The same protection is required in the gcloud, JAWS, and simulator backend helpers, so they were modified to make use of it.

Adopted app version 1.24.1 for CSM 1.5.5 (helm chart 4.0.3)
Adopted app version 1.25.1 for CSM 1.6.2 (helm chart 5.0.2)
Adopted app version 1.28.0 for CSM 1.7.0 (helm chart 5.1.3)

## Issues and Related PRs

* [CASMHMS-6477](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6477)

## Testing

Tested on:

  * `gamora` (1.6)
  * `mug` (1.7)
  * `slice` (1.5)

Test description:

Tested the CSM 1.6.2 version of both cray-hms-rts and cray-hms-rts-snmp on gamora.  Confirmed no issues talking SNMP to the leaf switches (SNMP wasn't enabled on the spine switches) and no issues talking JAWS to the iPDU.  Watched logs for issues and confirmed same log output with and without my changes.  Examined the internal redis database to ensure it was identical with and without my changes.

Tested the CSM 1.7.0 version of cray-hms-rts-snmp on mug.  Confirmed no issues talking SNMP to both the leaf and spine switches (SNMP was enabled on both).  There are no iPDUs on mug.

Tested the CSM 1.5.5 version of cray-hms-rts-snmp on slice to ensure no deviant issues in the 1.5.5 version.

## Risks and Mitigations

Extending the use of `redisActivePipelineMux` into the JAWS backend helper creates a risk associated with extending the time required for initial PDU discovery.  Because the Redis active pipeline is now, correctly, gated and serialized, it will take longer to discover all of the initial PDU devices.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable